### PR TITLE
fix(checkout): allow x-company-id in CORS preflight and wrap transactional flow in EF execution strategy to avoid NpgsqlRetryingExecutionStrategy errors

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -366,7 +366,8 @@ try
             context.Response.Headers["Access-Control-Allow-Origin"] = origin;
             context.Response.Headers["Vary"] = "Origin";
             context.Response.Headers["Access-Control-Allow-Credentials"] = "true";
-            context.Response.Headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization, X-Requested-With, X-CSRF-Token";
+            // Incluir headers personalizados necesarios por el frontend (p. ej., x-company-id)
+            context.Response.Headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization, X-Requested-With, X-CSRF-Token, X-Company-Id, x-company-id";
             context.Response.Headers["Access-Control-Allow-Methods"] = "GET,POST,PUT,DELETE,PATCH,OPTIONS";
         }
         if (string.Equals(context.Request.Method, "OPTIONS", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
- Add x-company-id to Access-Control-Allow-Headers in preflight middleware
- Use Database.CreateExecutionStrategy with explicit transaction for checkout flow
- Prevents 500 caused by user-initiated transaction under retry strategy
